### PR TITLE
Add macOS framework version

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -170,6 +170,7 @@ set_target_properties(${QCA_LIB_NAME} PROPERTIES
                       DEFINE_SYMBOL QCA_MAKEDLL
                       PUBLIC_HEADER "${public_HEADERS}"
                       FRAMEWORK ${OSX_FRAMEWORK}
+                      FRAMEWORK_VERSION ${QCA_LIB_MAJOR_VERSION}
                       EXPORT_NAME ${QCA_LIB_NAME}
                       )
 


### PR DESCRIPTION
Is **major.minor**, though could be just **major**, like Qt, Qwt, etc. For example:

```
FRAMEWORK_VERSION ${QCA_LIB_MAJOR_VERSION}
```

Creates framework paths like:

```
${QCA_LIBRARY_INSTALL_DIR}/qca-qt5.framework/Versions/2.1/
OR
${QCA_LIBRARY_INSTALL_DIR}/qca-qt5.framework/Versions/2/
```

Whether it should be **major.minor** or just **major** is relative to how the project handles versioning and API or SO breaks. Regardless, current path is probably _too restrictive_ (kind of defeating one benefit of using frameworks):

```
${QCA_LIBRARY_INSTALL_DIR}/qca-qt5.framework/Versions/2.1.3/
```