### PR TITLE
For C++11, explicitly mark throwing destructors `noexcept(false)`

### DIFF
--- a/src/botantools/botan/alloc_mmap/mmap_mem.cpp
+++ b/src/botantools/botan/alloc_mmap/mmap_mem.cpp
@@ -107,7 +107,7 @@ void* MemoryMapping_Allocator::alloc_block(u32bit n)
             umask(old_umask);
             }
 
-         ~TemporaryFile()
+         ~TemporaryFile() NOEXCEPT
             {
             delete[] filepath;
             if(fd != -1 && close(fd) == -1)

--- a/src/botantools/botan/botan/allocate.h
+++ b/src/botantools/botan/botan/allocate.h
@@ -40,6 +40,12 @@ namespace QCA { // WRAPNS_LINE
 #include <string>
 namespace QCA { // WRAPNS_LINE
 
+#if __cplusplus >= 201103L
+#define NOEXCEPT noexcept(false)
+#else
+#define NOEXCEPT
+#endif
+
 namespace Botan {
 
 /*************************************************
@@ -58,7 +64,7 @@ class Allocator
       virtual void init() {}
       virtual void destroy() {}
 
-      virtual ~Allocator() {}
+      virtual ~Allocator() NOEXCEPT {}
    };
 
 /*************************************************

--- a/src/botantools/botan/botan/mem_pool.h
+++ b/src/botantools/botan/botan/mem_pool.h
@@ -63,7 +63,7 @@ class Pooling_Allocator : public Allocator
       void destroy();
 
       Pooling_Allocator(u32bit, bool);
-      ~Pooling_Allocator();
+      ~Pooling_Allocator() NOEXCEPT;
    private:
       void get_more_core(u32bit);
       byte* allocate_blocks(u32bit);

--- a/src/botantools/botan/mem_pool.cpp
+++ b/src/botantools/botan/mem_pool.cpp
@@ -171,7 +171,7 @@ Pooling_Allocator::Pooling_Allocator(u32bit p_size, bool) :
 /*************************************************
 * Pooling_Allocator Destructor                   *
 *************************************************/
-Pooling_Allocator::~Pooling_Allocator()
+Pooling_Allocator::~Pooling_Allocator() NOEXCEPT
    {
    delete mutex;
    if(blocks.size())


### PR DESCRIPTION
In C++11 and later, destructors default to `noexcept(true)`.  Any throw statements in those destructors become calls to `std::terminate()`.  To enable the pre-C++11 intended behavior, all such throwing destructors need to be explicitly designated `noexcept(false)`.