### PR TITLE
No setuid on Android

### DIFF
--- a/src/qca_core.cpp
+++ b/src/qca_core.cpp
@@ -224,7 +224,7 @@ void init(MemoryMode mode, int prealloc)
 
 	if(drop_root)
 	{
-#ifdef Q_OS_UNIX
+#if defined(Q_OS_UNIX) && !defined(Q_OS_ANDROID)
 		setuid(getuid());
 #endif
 	}


### PR DESCRIPTION
QCA crashes during initialization on Android 9, as can be seen in https://github.com/opengisch/QField/issues/291

Relevant parts of the [backtrace here](https://github.com/opengisch/QField/issues/291#issuecomment-414917279)

```
08-21 18:42:52.240 29595 29595 F DEBUG   : pid: 29562, tid: 29590, name: QtMainThread  >>> ch.opengis.qfield <<<
08-21 18:42:52.240 29595 29595 F DEBUG   : signal 31 (SIGSYS), code 1 (SYS_SECCOMP), fault addr --------
08-21 18:42:52.240 29595 29595 F DEBUG   : Cause: seccomp prevented call to disallowed arm system call 213
```

```
#00 pc 00054f98  /system/lib/libc.so (setuid+12)
#01 pc 0004ab31  /data/app/ch.opengis.qfield-UoBGQ4wNBC2DfegHpQH5wg==/lib/arm/libqca-qt5.so #02 pc 0004ac05  /data/app/ch.opengis.qfield-UoBGQ4wNBC2DfegHpQH5wg==/lib/arm/libqca-qt5.so (QCA::Initializer::Initializer(QCA::MemoryMode, int)+8)
#03 pc 0026cda9  /data/app/ch.opengis.qfield-UoBGQ4wNBC2DfegHpQH5wg==/lib/arm/libqgis_core.so (QgsAuthManager::init(QString const&, QString const&)+52)
```

setuid calls are not allowed starting from Android O (https://android-developers.googleblog.com/2017/07/seccomp-filter-in-android-o.html). It's not completely clear to me, what impact this patch has on older Android versions.