### PR TITLE
call of setuid crashes android applications

### DIFF
--- a/src/qca_core.cpp
+++ b/src/qca_core.cpp
@@ -225,7 +225,7 @@ void init(MemoryMode mode, int prealloc)
 
 	if(drop_root)
 	{
-#ifdef Q_OS_UNIX
+#if defined(Q_OS_UNIX) && !defined(Q_OS_ANDROID)
 		setuid(getuid());
 #endif
 	}


### PR DESCRIPTION
to be able to run the application on android, we have to remove the call of setid which crashes the application on runtime (when QCA is initialized)

https://github.com/lutraconsulting/input-sdk/blob/master/android/recipes/qca/patches/no_setuid.patch